### PR TITLE
Make demo cards navigable and tidy memo dependencies

### DIFF
--- a/frontend/src/components/DemoCard.tsx
+++ b/frontend/src/components/DemoCard.tsx
@@ -9,10 +9,14 @@ interface DemoCardProps {
  */
 export const DemoCard: React.FC<DemoCardProps> = ({ demo }) => {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow duration-300">
+    <a
+      href={demo.path}
+      className="block bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden transition-shadow duration-300 hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      aria-label={`${demo.title} の詳細へ移動`}
+    >
       <div className="relative h-48 w-full">
-        <img 
-          src={demo.image} 
+        <img
+          src={demo.image}
           alt={demo.title}
           className="w-full h-full object-cover"
         />
@@ -26,7 +30,7 @@ export const DemoCard: React.FC<DemoCardProps> = ({ demo }) => {
         </p>
         <div className="flex flex-wrap gap-2">
           {demo.tags.map((tag) => (
-            <span 
+            <span
               key={tag}
               className="inline-block px-3 py-1 text-xs font-semibold text-blue-600 dark:text-blue-400 bg-blue-100 dark:bg-blue-900/30 rounded-full"
             >
@@ -35,6 +39,6 @@ export const DemoCard: React.FC<DemoCardProps> = ({ demo }) => {
           ))}
         </div>
       </div>
-    </div>
+    </a>
   );
 };

--- a/frontend/src/pages/TopPage.tsx
+++ b/frontend/src/pages/TopPage.tsx
@@ -2,32 +2,33 @@ import { useState, useMemo } from 'react';
 import { DemoCard } from '../components/DemoCard';
 import { DemoFilter } from '../components/DemoFilter';
 import { mockDemos } from '../utils/mockData';
-import type { AzureService } from '../types/demo';
+import type { AzureService, Demo } from '../types/demo';
 
 /**
  * トップページ - デモショーケース一覧
  */
 export const TopPage: React.FC = () => {
   const [selectedTags, setSelectedTags] = useState<AzureService[]>([]);
+  const [demos] = useState<Demo[]>(mockDemos);
 
   // すべてのタグを抽出（重複を除く）
   const allTags = useMemo(() => {
     const tags = new Set<AzureService>();
-    mockDemos.forEach((demo) => {
+    demos.forEach((demo) => {
       demo.tags.forEach((tag) => tags.add(tag));
     });
     return Array.from(tags).sort();
-  }, []);
+  }, [demos]);
 
   // フィルタリングされたデモ
   const filteredDemos = useMemo(() => {
     if (selectedTags.length === 0) {
-      return mockDemos;
+      return demos;
     }
-    return mockDemos.filter((demo) =>
+    return demos.filter((demo) =>
       selectedTags.some((tag) => demo.tags.includes(tag))
     );
-  }, [selectedTags]);
+  }, [selectedTags, demos]);
 
   // タグの切り替え
   const handleTagToggle = (tag: AzureService) => {


### PR DESCRIPTION
## Summary
- wrap demo cards in accessible links so users can navigate to the advertised paths
- store mock demos in state so memoized selectors can safely depend on the dataset
- update memo dependencies to respect future changes to the demo list

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fb74f7bb4c8328abcbe273c291a1c7