### PR TITLE
Include index.html in Docker build context

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,7 @@ COPY tsconfig.json tsconfig.app.json tsconfig.node.json ./
 COPY vite.config.ts .
 COPY postcss.config.cjs .
 COPY tailwind.config.ts .
+COPY index.html .
 COPY src ./src
 COPY public ./public
 


### PR DESCRIPTION
## Summary
- copy the frontend's index.html into the Docker build context before running the Vite build

## Testing
- pnpm install
- pnpm build *(fails: missing Vite type declarations due to registry auth requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68fb826a73148328a5aee9a57339340f