### PR TITLE
Fix infra workflow permissions configuration

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: read
   actions: write
-  variables: write
 
 env:
   AZURE_RESOURCE_GROUP_NAME: ${{ vars.AZURE_RESOURCE_GROUP_NAME }}


### PR DESCRIPTION
## Summary
- remove the unsupported `variables` permission from the infra deployment workflow so the file parses correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_6902f0ef3bd08328bc12ca4fdfe2f69a