### PR TITLE
Include index.html in frontend Docker build context

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,7 @@ COPY tsconfig.json tsconfig.app.json tsconfig.node.json ./
 COPY vite.config.ts .
 COPY postcss.config.cjs .
 COPY tailwind.config.ts .
+COPY index.html .
 COPY src ./src
 COPY public ./public
 


### PR DESCRIPTION
## Summary
- copy the Vite entry point into the Docker build context so the production build can find index.html

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_690337ca94a08328918c840f79e7b08b