### PR TITLE
Build frontend image with both tags

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -57,8 +57,14 @@ jobs:
           IMAGE_NAME: ${{ env.CONTAINER_IMAGE_NAME }}
         run: |
           IMAGE_TAG="${LOGIN_SERVER}/${IMAGE_NAME}:${GITHUB_SHA}"
-          docker build -f frontend/Dockerfile -t "$IMAGE_TAG" frontend
+          LATEST_TAG="${LOGIN_SERVER}/${IMAGE_NAME}:latest"
+          docker build \
+            -f frontend/Dockerfile \
+            -t "$IMAGE_TAG" \
+            -t "$LATEST_TAG" \
+            frontend
           docker push "$IMAGE_TAG"
+          docker push "$LATEST_TAG"
 
       - name: Publish artifact summary
         if: success()
@@ -67,4 +73,8 @@ jobs:
           IMAGE_NAME: ${{ env.CONTAINER_IMAGE_NAME }}
         run: |
           IMAGE_TAG="${LOGIN_SERVER}/${IMAGE_NAME}:${GITHUB_SHA}"
-          echo "Built and pushed image: $IMAGE_TAG" >> "$GITHUB_STEP_SUMMARY"
+          LATEST_TAG="${LOGIN_SERVER}/${IMAGE_NAME}:latest"
+          {
+            echo "Built and pushed image: $IMAGE_TAG"
+            echo "Updated latest tag: $LATEST_TAG"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- build the frontend container image once while applying both the commit-specific and latest tags
- continue pushing both tags so the immutable revision and mutable latest reference stay updated together

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_69033a01fc8c832887d1f8912c7b09ea